### PR TITLE
Pass the full event object as $event to ngClick and ngSubmit callbacks

### DIFF
--- a/src/promise-btn-d.js
+++ b/src/promise-btn-d.js
@@ -154,13 +154,13 @@ angular.module('angularPromiseButtons')
                         el.unbind(eventToHandle);
 
                         // rebind, but this time watching it's return value
-                        el.bind(eventToHandle, function() {
+                        el.bind(eventToHandle, function(event) {
                             // Make sure we run the $digest cycle
                             scope.$apply(function() {
                                 callbacks.forEach(function(cb) {
                                     // execute function on parent scope
                                     // as we're in an isolate scope here
-                                    var promise = cb(scope.$parent, {$event: eventToHandle});
+                                    var promise = cb(scope.$parent, {$event: event});
 
                                     // only init watcher if not done before
                                     if (!promiseWatcher) {


### PR DESCRIPTION
Angular's `ngClick` and `ngSubmit` directives expose the full event object as [$event](https://docs.angularjs.org/guide/expression#-event-) within the scope of the expression. Using `promise-btn` breaks this and passes just the string 'click' or 'submit' instead. This patch fixes this behaviour.